### PR TITLE
fix(ui): 🐛 suppress console window on Windows

### DIFF
--- a/rs_watson_ui/src/main.rs
+++ b/rs_watson_ui/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
+
 use std::collections::BTreeMap;
 
 use chrono::{DateTime, Duration, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};


### PR DESCRIPTION
## Summary
- Added `#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]` to `rs_watson_ui/src/main.rs`
- The UI now launches as a proper Windows GUI application — no terminal window alongside it
- No effect on Linux or macOS builds

## Test plan
- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo fmt` applied
- [ ] Manually tested on Windows: UI opens without a console window

## Related
Closes #8