### PR TITLE
feat(ci): ✨ package rs_watson_ui as macOS .app bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,8 @@ jobs:
 
       # --- Package -----------------------------------------------------------
 
-      - name: Package (Linux / macOS)
-        if: matrix.archive_ext == 'tar.gz'
+      - name: Package (Linux)
+        if: runner.os == 'Linux'
         shell: bash
         run: |
           TAG="${GITHUB_REF_NAME}"
@@ -75,6 +75,21 @@ jobs:
             -C target/release \
             ${{ matrix.cli_bin }} \
             ${{ matrix.ui_bin }}
+          echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
+
+      - name: Package (macOS — app bundle)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          ARCHIVE="rs-watson-${TAG}-${{ matrix.name }}.tar.gz"
+          mkdir -p rs_watson_ui.app/Contents/MacOS
+          cp target/release/rs_watson_ui rs_watson_ui.app/Contents/MacOS/rs_watson_ui
+          cp rs_watson_ui/Info.plist rs_watson_ui.app/Contents/Info.plist
+          mkdir staging
+          cp target/release/${{ matrix.cli_bin }} staging/
+          cp -r rs_watson_ui.app staging/
+          tar -czf "${ARCHIVE}" -C staging .
           echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
 
       - name: Package (Windows)

--- a/rs_watson_ui/Info.plist
+++ b/rs_watson_ui/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>rs_watson_ui</string>
+    <key>CFBundleIdentifier</key>
+    <string>de.pkeil.rs-watson-ui</string>
+    <key>CFBundleName</key>
+    <string>rs_watson_ui</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Added `rs_watson_ui/Info.plist` with the minimal keys required for a macOS app bundle (`CFBundleExecutable`, `CFBundleIdentifier`, `CFBundleName`, `CFBundlePackageType`, `NSHighResolutionCapable`)
- Split the release workflow packaging step into separate Linux and macOS paths
- macOS now assembles `rs_watson_ui.app/Contents/MacOS/rs_watson_ui` + `Info.plist`, stages it alongside the `watson` CLI binary, and archives the whole thing — so the release contains a proper `.app` bundle instead of a raw binary
- Linux and Windows packaging is unchanged

## Test plan
- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo fmt` applied
- [ ] Release workflow runs on next tag push and produces `rs_watson_ui.app` in the macOS archive

## Related
Closes #7