### PR TITLE
feat(cli): ✨ short IDs in log, positional ID for edit/remove, limit s…

### DIFF
--- a/rs_watson_cli/src/commands/frames.rs
+++ b/rs_watson_cli/src/commands/frames.rs
@@ -160,6 +160,7 @@ pub(super) fn cmd_add<S: Storage<Error: std::error::Error + Send + Sync + 'stati
 
 pub(super) fn cmd_edit<S: Storage<Error: std::error::Error + Send + Sync + 'static>>(
     watson: &Watson<S>,
+    id: Option<String>,
 ) -> Result<()> {
     let mut frames = watson.log().map_err(w_err)?;
     if frames.is_empty() {
@@ -168,14 +169,19 @@ pub(super) fn cmd_edit<S: Storage<Error: std::error::Error + Send + Sync + 'stat
     }
     frames.reverse();
 
-    let items = frame_selector_items(&frames);
-    let selection = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("Select frame to edit")
-        .items(&items)
-        .default(0)
-        .interact()?;
-
-    let frame = &frames[selection];
+    let frame = if let Some(short) = id {
+        find_by_short_id(&frames, &short)?.clone()
+    } else {
+        let recent = recent_frames(&frames);
+        let items = frame_selector_items(recent);
+        let selection = Select::with_theme(&ColorfulTheme::default())
+            .with_prompt("Select frame to edit")
+            .items(&items)
+            .default(0)
+            .interact()?;
+        recent[selection].clone()
+    };
+    let frame = &frame;
     println!();
 
     let new_project: String = Input::with_theme(&ColorfulTheme::default())
@@ -212,6 +218,7 @@ pub(super) fn cmd_edit<S: Storage<Error: std::error::Error + Send + Sync + 'stat
 
 pub(super) fn cmd_remove<S: Storage<Error: std::error::Error + Send + Sync + 'static>>(
     watson: &Watson<S>,
+    id: Option<String>,
 ) -> Result<()> {
     let mut frames = watson.log().map_err(w_err)?;
     if frames.is_empty() {
@@ -220,14 +227,19 @@ pub(super) fn cmd_remove<S: Storage<Error: std::error::Error + Send + Sync + 'st
     }
     frames.reverse();
 
-    let items = frame_selector_items(&frames);
-    let selection = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("Select frame to remove")
-        .items(&items)
-        .default(0)
-        .interact()?;
-
-    let frame = &frames[selection];
+    let frame = if let Some(short) = id {
+        find_by_short_id(&frames, &short)?.clone()
+    } else {
+        let recent = recent_frames(&frames);
+        let items = frame_selector_items(recent);
+        let selection = Select::with_theme(&ColorfulTheme::default())
+            .with_prompt("Select frame to remove")
+            .items(&items)
+            .default(0)
+            .interact()?;
+        recent[selection].clone()
+    };
+    let frame = &frame;
     let confirmed = Confirm::with_theme(&ColorfulTheme::default())
         .with_prompt(format!(
             "Remove \"{}\" ({} → {})?",
@@ -253,13 +265,47 @@ pub(super) fn cmd_remove<S: Storage<Error: std::error::Error + Send + Sync + 'st
     Ok(())
 }
 
+/// How many frames the interactive selector shows (most recent first).
+const SELECTOR_LIMIT: usize = 25;
+
+/// Returns a short 8-character ID prefix for display.
+fn short_id(frame: &rs_watson::Frame) -> String {
+    frame.id.to_string().replace('-', "")[..8].to_string()
+}
+
+/// Returns the most recent up to SELECTOR_LIMIT frames (already in newest-first order).
+fn recent_frames(frames: &[rs_watson::Frame]) -> &[rs_watson::Frame] {
+    &frames[..frames.len().min(SELECTOR_LIMIT)]
+}
+
+/// Finds a frame by short ID prefix (case-insensitive). Errors if 0 or >1 match.
+fn find_by_short_id<'a>(
+    frames: &'a [rs_watson::Frame],
+    prefix: &str,
+) -> Result<&'a rs_watson::Frame> {
+    let lower = prefix.to_lowercase();
+    let matches: Vec<_> = frames
+        .iter()
+        .filter(|f| short_id(f).starts_with(&lower))
+        .collect();
+    match matches.len() {
+        0 => anyhow::bail!("No frame found with ID starting with \"{}\"", prefix),
+        1 => Ok(matches[0]),
+        _ => anyhow::bail!(
+            "Ambiguous ID \"{}\": {} frames match — use more characters",
+            prefix,
+            matches.len()
+        ),
+    }
+}
+
 /// Builds the display strings for the interactive frame selector used by edit and remove.
 fn frame_selector_items(frames: &[rs_watson::Frame]) -> Vec<String> {
     frames
         .iter()
         .map(|f| {
             format!(
-                "{}  {} → {}  {:<10}  {}{}",
+                "{}  {} → {}  {:<10}  {}{}  {}",
                 f.start.format("%Y-%m-%d"),
                 fmt_time(f.start),
                 fmt_time(f.end),
@@ -270,6 +316,7 @@ fn frame_selector_items(frames: &[rs_watson::Frame]) -> Vec<String> {
                 } else {
                     format!("  [{}]", f.tags.join(", "))
                 },
+                short_id(f),
             )
         })
         .collect()

--- a/rs_watson_cli/src/commands/mod.rs
+++ b/rs_watson_cli/src/commands/mod.rs
@@ -80,7 +80,11 @@ pub(crate) enum Commands {
         epic: bool,
     },
     /// Edit a recorded frame interactively
-    Edit,
+    Edit {
+        /// Short frame ID to edit directly, skipping the selector (e.g. "a1b2c3d4")
+        #[arg(value_name = "ID")]
+        id: Option<String>,
+    },
     /// Add a completed frame retroactively
     Add {
         /// Project name
@@ -97,7 +101,11 @@ pub(crate) enum Commands {
         to: String,
     },
     /// Remove a recorded frame interactively
-    Remove,
+    Remove {
+        /// Short frame ID to remove directly, skipping the selector (e.g. "a1b2c3d4")
+        #[arg(value_name = "ID")]
+        id: Option<String>,
+    },
     /// Rename a project across all recorded frames
     Rename {
         /// Current project name
@@ -205,8 +213,8 @@ pub(crate) fn dispatch<S: Storage<Error: std::error::Error + Send + Sync + 'stat
             from,
             to,
         } => frames::cmd_add(&watson, project, tags, from, to, config),
-        Commands::Edit => frames::cmd_edit(&watson),
-        Commands::Remove => frames::cmd_remove(&watson),
+        Commands::Edit { id } => frames::cmd_edit(&watson, id),
+        Commands::Remove { id } => frames::cmd_remove(&watson, id),
         Commands::Rename { from, to } => meta::cmd_rename(&watson, from, to),
         Commands::Projects => meta::cmd_projects(&watson),
         Commands::Tags => meta::cmd_tags(&watson),

--- a/rs_watson_cli/src/format.rs
+++ b/rs_watson_cli/src/format.rs
@@ -57,14 +57,22 @@ pub(crate) fn print_frames_grouped(frames: &[Frame]) {
         );
 
         for frame in &day_frames {
+            let sid: String = frame
+                .id
+                .to_string()
+                .replace('-', "")
+                .chars()
+                .take(8)
+                .collect();
             println!(
-                "  {}  {}  {}   {:<12}  {}{}",
+                "  {}  {}  {}   {:<12}  {}{}  {}",
                 fmt_time(frame.start).bright_white(),
                 "→".white(),
                 fmt_time(frame.end).bright_white(),
                 fmt_duration(frame.end - frame.start).magenta().bold(),
                 frame.project.yellow().bold(),
                 fmt_tags(&frame.tags),
+                sid.bright_black(),
             );
         }
         println!();


### PR DESCRIPTION
…elector

- watson log now shows an 8-char short ID per frame (dimmed)
- watson edit/remove accept an optional positional ID to skip the selector
- interactive selector limited to the 25 most recent frames
- short IDs are also visible in the selector for future reference

Closes #12