### PR TITLE
feat(cli): ✨ add --project and --tag filters to log, today, report

### DIFF
--- a/rs_watson_cli/src/commands/frames.rs
+++ b/rs_watson_cli/src/commands/frames.rs
@@ -13,12 +13,15 @@ use crate::format::{
 use crate::time_utils::{check_future, parse_at, prompt_time};
 use rs_watson::config::Config;
 
-use super::{apply_date_filter, w_err};
+use super::{apply_date_filter, apply_project_tag_filter, w_err};
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn cmd_log<S: Storage<Error: std::error::Error + Send + Sync + 'static>>(
     watson: &Watson<S>,
     from: Option<String>,
     to: Option<String>,
+    project: Option<String>,
+    tags: Vec<String>,
     limit: Option<usize>,
     offset: Option<usize>,
     config: &Config,
@@ -47,6 +50,8 @@ pub(super) fn cmd_log<S: Storage<Error: std::error::Error + Send + Sync + 'stati
         }
     }
 
+    let mut frames = apply_project_tag_filter(frames, project.as_deref(), &tags);
+
     let effective_limit =
         limit.or_else(|| (config.log.default_limit > 0).then_some(config.log.default_limit));
     let total = frames.len();
@@ -63,6 +68,8 @@ pub(super) fn cmd_log<S: Storage<Error: std::error::Error + Send + Sync + 'stati
 
 pub(super) fn cmd_today<S: Storage<Error: std::error::Error + Send + Sync + 'static>>(
     watson: &Watson<S>,
+    project: Option<String>,
+    tags: Vec<String>,
     epic: bool,
     config: &Config,
 ) -> Result<()> {
@@ -84,6 +91,8 @@ pub(super) fn cmd_today<S: Storage<Error: std::error::Error + Send + Sync + 'sta
         frames.push(active.stop(now));
     }
 
+    let frames = apply_project_tag_filter(frames, project.as_deref(), &tags);
+
     if frames.is_empty() {
         println!("{}", "No frames recorded today.".bright_black());
     } else if epic {
@@ -101,6 +110,8 @@ pub(super) fn cmd_report<S: Storage<Error: std::error::Error + Send + Sync + 'st
     watson: &Watson<S>,
     from: Option<String>,
     to: Option<String>,
+    project: Option<String>,
+    tags: Vec<String>,
     epic: bool,
     config: &Config,
 ) -> Result<()> {
@@ -127,6 +138,8 @@ pub(super) fn cmd_report<S: Storage<Error: std::error::Error + Send + Sync + 'st
             frames.push(virtual_frame);
         }
     }
+
+    let frames = apply_project_tag_filter(frames, project.as_deref(), &tags);
 
     if frames.is_empty() {
         println!("{}", "No frames recorded.".bright_black());

--- a/rs_watson_cli/src/commands/mod.rs
+++ b/rs_watson_cli/src/commands/mod.rs
@@ -54,6 +54,12 @@ pub(crate) enum Commands {
         /// End date filter (YYYY-MM-DD or shortcuts: today, yesterday, week, month)
         #[arg(long, value_name = "DATE")]
         to: Option<String>,
+        /// Filter by project name (exact match)
+        #[arg(short = 'p', long, value_name = "PROJECT")]
+        project: Option<String>,
+        /// Filter by tag — can be given multiple times (all must match)
+        #[arg(short = 't', long = "tag", value_name = "TAG")]
+        tags: Vec<String>,
         /// Show only the last N frames
         #[arg(long, value_name = "N")]
         limit: Option<usize>,
@@ -63,6 +69,12 @@ pub(crate) enum Commands {
     },
     /// Show aggregated report for today
     Today {
+        /// Filter by project name (exact match)
+        #[arg(short = 'p', long, value_name = "PROJECT")]
+        project: Option<String>,
+        /// Filter by tag — can be given multiple times (all must match)
+        #[arg(short = 't', long = "tag", value_name = "TAG")]
+        tags: Vec<String>,
         /// Group by epic instead of project (requires epics in config.toml)
         #[arg(long)]
         epic: bool,
@@ -75,6 +87,12 @@ pub(crate) enum Commands {
         /// End date filter (YYYY-MM-DD or shortcuts: today, yesterday, week, month)
         #[arg(long, value_name = "DATE")]
         to: Option<String>,
+        /// Filter by project name (exact match)
+        #[arg(short = 'p', long, value_name = "PROJECT")]
+        project: Option<String>,
+        /// Filter by tag — can be given multiple times (all must match)
+        #[arg(short = 't', long = "tag", value_name = "TAG")]
+        tags: Vec<String>,
         /// Group by epic instead of project (requires epics in config.toml)
         #[arg(long)]
         epic: bool,
@@ -161,6 +179,19 @@ fn w_err<E: std::fmt::Display>(e: E) -> anyhow::Error {
     anyhow::anyhow!("{e}")
 }
 
+pub(super) fn apply_project_tag_filter(
+    frames: Vec<rs_watson::Frame>,
+    project: Option<&str>,
+    tags: &[String],
+) -> Vec<rs_watson::Frame> {
+    frames
+        .into_iter()
+        .filter(|f| {
+            project.is_none_or(|p| f.project == p) && tags.iter().all(|t| f.tags.contains(t))
+        })
+        .collect()
+}
+
 pub(super) fn apply_date_filter(
     frames: Vec<rs_watson::Frame>,
     from: Option<String>,
@@ -202,11 +233,23 @@ pub(crate) fn dispatch<S: Storage<Error: std::error::Error + Send + Sync + 'stat
         Commands::Log {
             from,
             to,
+            project,
+            tags,
             limit,
             offset,
-        } => frames::cmd_log(&watson, from, to, limit, offset, config),
-        Commands::Today { epic } => frames::cmd_today(&watson, epic, config),
-        Commands::Report { from, to, epic } => frames::cmd_report(&watson, from, to, epic, config),
+        } => frames::cmd_log(&watson, from, to, project, tags, limit, offset, config),
+        Commands::Today {
+            project,
+            tags,
+            epic,
+        } => frames::cmd_today(&watson, project, tags, epic, config),
+        Commands::Report {
+            from,
+            to,
+            project,
+            tags,
+            epic,
+        } => frames::cmd_report(&watson, from, to, project, tags, epic, config),
         Commands::Add {
             project,
             tags,


### PR DESCRIPTION
## Summary
- Added `-p / --project <PROJECT>` (exact match) and `-t / --tag <TAG>` (repeatable, all must match) to `log`, `today`, and `report`
- New `apply_project_tag_filter` helper in `commands/mod.rs` — applies after date-range filter and before `--limit`/`--offset` in `log`
- No changes to the storage layer or core library — pure presentation-layer filtering

## Examples
```sh
watson report --project backend
watson report --from week --tag api --tag auth
watson log -p frontend -t css
watson today -p backend
```

## Test plan
- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo fmt` applied
- [ ] Manually tested: `watson report -p <project>`, `watson log -t <tag>`, combined filters

## Related
Closes #15