### PR TITLE
build(workspace): 🔧 bump all crates to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,7 +2984,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rs_watson"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "rs_watson_cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "rs_watson_export"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "csv",
@@ -3030,7 +3030,7 @@ dependencies = [
 
 [[package]]
 name = "rs_watson_storage"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -3044,7 +3044,7 @@ dependencies = [
 
 [[package]]
 name = "rs_watson_ui"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/rs_watson/Cargo.toml
+++ b/rs_watson/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs_watson"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 
 [features]
@@ -10,7 +10,7 @@ storage-sqlite = ["rs_watson_storage/sqlite"]
 [dependencies]
 chrono = { version = "0.4.44", features = ["serde"] }
 dirs = "6.0.0"
-rs_watson_storage = { version = "0.2.1", path = "../rs_watson_storage", default-features = false }
+rs_watson_storage = { version = "0.3.0", path = "../rs_watson_storage", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.18"
 toml = "1.1.2"

--- a/rs_watson_cli/Cargo.toml
+++ b/rs_watson_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs_watson_cli"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 
 [[bin]]
@@ -22,9 +22,9 @@ clap_complete = "4.6.5"
 dialoguer = "0.12.0"
 dirs = "6.0.0"
 owo-colors = "4.3.0"
-rs_watson = { version = "0.2.1", path = "../rs_watson" }
-rs_watson_export = { version = "0.2.1", path = "../rs_watson_export" }
-rs_watson_storage = { version = "0.2.1", path = "../rs_watson_storage", default-features = false }
+rs_watson = { version = "0.3.0", path = "../rs_watson" }
+rs_watson_export = { version = "0.3.0", path = "../rs_watson_export" }
+rs_watson_storage = { version = "0.3.0", path = "../rs_watson_storage", default-features = false }
 serde_json = "1.0.149"
 toml = "1.1.2"
 

--- a/rs_watson_export/Cargo.toml
+++ b/rs_watson_export/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "rs_watson_export"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]
 chrono = { version = "0.4.44", features = ["serde"] }
 csv = "1.4.0"
-rs_watson = { version = "0.2.1", path = "../rs_watson" }
+rs_watson = { version = "0.3.0", path = "../rs_watson" }
 thiserror = "2.0.18"
 
 [dev-dependencies]

--- a/rs_watson_storage/Cargo.toml
+++ b/rs_watson_storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs_watson_storage"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 
 [features]

--- a/rs_watson_ui/Cargo.toml
+++ b/rs_watson_ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs_watson_ui"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]
@@ -8,6 +8,6 @@ anyhow = "1.0.102"
 chrono = "0.4.44"
 dirs = "6.0.0"
 eframe = "0.34.2"
-rs_watson = { version = "0.2.1", path = "../rs_watson", features = ["storage-sqlite"] }
-rs_watson_storage = { version = "0.2.1", path = "../rs_watson_storage", default-features = false }
+rs_watson = { version = "0.3.0", path = "../rs_watson", features = ["storage-sqlite"] }
+rs_watson_storage = { version = "0.3.0", path = "../rs_watson_storage", default-features = false }
 uuid = "1.23.1"


### PR DESCRIPTION
## Summary
- Bumps all five workspace crates from `0.2.1` → `0.3.0`
- Updates internal cross-crate dependency versions accordingly
- No logic changes

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)