### PR TITLE
ci: ⚙️ lint tests and benches with clippy --all-targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: cargo fmt --check
 
       - name: cargo clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
     name: Test (${{ matrix.os }})

--- a/rs_watson_cli/tests/cli.rs
+++ b/rs_watson_cli/tests/cli.rs
@@ -86,7 +86,7 @@ fn statusline_includes_completed_frames_in_total() {
         .clone();
 
     let line = String::from_utf8(out).unwrap();
-    let time_part = line.trim().split_whitespace().nth(1).unwrap();
+    let time_part = line.split_whitespace().nth(1).unwrap();
     let parts: Vec<u64> = time_part.split(':').map(|s| s.parse().unwrap()).collect();
     let total_minutes = parts[0] * 60 + parts[1];
     assert!(


### PR DESCRIPTION
## Summary
- CI ran `cargo clippy -- -D warnings`, which only lints lib and bin targets — lints in tests, benches and examples never failed the build
- Widen the lint job to `cargo clippy --workspace --all-targets -- -D warnings`
- Fix the one lint this uncovered: redundant `trim()` before `split_whitespace()` in the statusline integration test

## Test plan
- [x] `cargo test` passes (145 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt` applied
- [x] Manually verified the lint failed before the fix and passes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HimprbqZLPYUKtkiAuAvUJ