### PR TITLE
build(workspace): 🔧 give rs_watson a default storage backend

### DIFF
--- a/rs_watson/Cargo.toml
+++ b/rs_watson/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.3.0"
 edition = "2024"
 
 [features]
+# Default so the crate builds standalone; consumers that pick their own
+# backend must set `default-features = false`.
+default = ["storage-sqlite"]
 storage-json = ["rs_watson_storage/json"]
 storage-sqlite = ["rs_watson_storage/sqlite"]
 

--- a/rs_watson_cli/Cargo.toml
+++ b/rs_watson_cli/Cargo.toml
@@ -22,7 +22,7 @@ clap_complete = "4.6.5"
 dialoguer = "0.12.0"
 dirs = "6.0.0"
 owo-colors = "4.3.0"
-rs_watson = { version = "0.3.0", path = "../rs_watson" }
+rs_watson = { version = "0.3.0", path = "../rs_watson", default-features = false }
 rs_watson_export = { version = "0.3.0", path = "../rs_watson_export" }
 rs_watson_storage = { version = "0.3.0", path = "../rs_watson_storage", default-features = false }
 serde_json = "1.0.149"

--- a/rs_watson_export/Cargo.toml
+++ b/rs_watson_export/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 chrono = { version = "0.4.44", features = ["serde"] }
 csv = "1.4.0"
-rs_watson = { version = "0.3.0", path = "../rs_watson" }
+rs_watson = { version = "0.3.0", path = "../rs_watson", default-features = false }
 thiserror = "2.0.18"
 
 [dev-dependencies]

--- a/rs_watson_ui/Cargo.toml
+++ b/rs_watson_ui/Cargo.toml
@@ -8,6 +8,6 @@ anyhow = "1.0.102"
 chrono = "0.4.44"
 dirs = "6.0.0"
 eframe = "0.34.2"
-rs_watson = { version = "0.3.0", path = "../rs_watson", features = ["storage-sqlite"] }
+rs_watson = { version = "0.3.0", path = "../rs_watson", default-features = false, features = ["storage-sqlite"] }
 rs_watson_storage = { version = "0.3.0", path = "../rs_watson_storage", default-features = false }
 uuid = "1.23.1"


### PR DESCRIPTION
## Summary
- `cargo build -p rs_watson` failed without a storage feature: the `compile_error!` guard in `config.rs` fired, but was buried under an E0308 and an unreachable-code error from the then-uninhabited `StorageProvider` enum
- `default = ["storage-sqlite"]` lets the crate build standalone
- all three consumers (`cli`, `export`, `ui`) now set `default-features = false`. Without this the `storage-json only` build pulled `rusqlite` in transitively through `rs_watson_export`, silently defeating the CI feature matrix

## Test plan
- [x] `cargo build -p rs_watson` (previously failed, now builds)
- [x] `cargo tree` before/after: `storage-json only` contains 0 `rusqlite`, `storage-sqlite only` contains it
- [x] full CI feature matrix locally — build **and** test for json-only, sqlite-only, both backends
- [x] `cargo test` (145 tests), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HimprbqZLPYUKtkiAuAvUJ