### PR TITLE
build(workspace): 🔧 deny unwrap/expect in production code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,9 @@ lto = true         # fat LTO: cross-crate inlining and dead-code elimination
 codegen-units = 1  # single codegen unit — slower compile, better output
 strip = true       # strip debug symbols from the final binary
 panic = "abort"    # no unwinding machinery — smaller binary, faster panics
+
+[workspace.lints.clippy]
+# CLAUDE.md: no unwrap()/expect() in production code paths.
+# clippy.toml exempts test code so tests stay readable.
+unwrap_used = "deny"
+expect_used = "deny"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/rs_watson/Cargo.toml
+++ b/rs_watson/Cargo.toml
@@ -15,3 +15,6 @@ serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.18"
 toml = "1.1.2"
 uuid = { version = "1.23.1", features = ["serde", "v4"] }
+
+[lints]
+workspace = true

--- a/rs_watson_cli/Cargo.toml
+++ b/rs_watson_cli/Cargo.toml
@@ -33,3 +33,6 @@ assert_cmd = "2.2.2"
 predicates = "3.1.4"
 tempfile = "3.27.0"
 uuid = { version = "1.23.1", features = ["v4"] }
+
+[lints]
+workspace = true

--- a/rs_watson_cli/src/time_utils.rs
+++ b/rs_watson_cli/src/time_utils.rs
@@ -22,7 +22,9 @@ pub(crate) fn parse_date(input: &str, week_start: WeekStart) -> Result<NaiveDate
             };
             Ok(today - Duration::days(days_back))
         }
-        "month" => Ok(today.with_day(1).expect("day 1 always valid")),
+        "month" => today
+            .with_day(1)
+            .context("failed to compute the first day of the current month"),
         s => NaiveDate::parse_from_str(s, "%Y-%m-%d").with_context(|| {
             format!("Invalid date \"{s}\", expected YYYY-MM-DD or: today, yesterday, week, month")
         }),

--- a/rs_watson_cli/tests/cli.rs
+++ b/rs_watson_cli/tests/cli.rs
@@ -1,3 +1,7 @@
+// Integration tests: `unwrap()` on setup helpers is fine here — the workspace
+// deny only targets production paths, and clippy.toml exempts only `#[test]` fns.
+#![allow(clippy::unwrap_used)]
+
 use assert_cmd::Command;
 use predicates::prelude::PredicateBooleanExt;
 use predicates::str::contains;

--- a/rs_watson_export/Cargo.toml
+++ b/rs_watson_export/Cargo.toml
@@ -12,3 +12,6 @@ thiserror = "2.0.18"
 [dev-dependencies]
 chrono = { version = "0.4.44", features = ["serde"] }
 uuid = { version = "1.23.1", features = ["v4", "serde"] }
+
+[lints]
+workspace = true

--- a/rs_watson_storage/Cargo.toml
+++ b/rs_watson_storage/Cargo.toml
@@ -21,3 +21,6 @@ rusqlite_migration = { version = "2.5.0", optional = true }
 
 [dev-dependencies]
 tempfile = "3.27.0"
+
+[lints]
+workspace = true

--- a/rs_watson_storage/src/sqlite.rs
+++ b/rs_watson_storage/src/sqlite.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 
 use chrono::{DateTime, Utc};
 use rusqlite::{Connection, params};
@@ -40,6 +40,18 @@ impl SqliteStorage {
             conn: Mutex::new(conn),
         })
     }
+
+    /// Locks the connection, recovering from a poisoned mutex instead of panicking.
+    ///
+    /// A panic while the guard is held cannot leave the `Connection` logically
+    /// inconsistent: an in-flight `Transaction` rolls back when it is dropped during
+    /// unwinding. Recovering is therefore preferable to propagating a panic — and the
+    /// release profile uses `panic = "abort"`, so poisoning can only occur in debug builds.
+    fn conn(&self) -> MutexGuard<'_, Connection> {
+        self.conn
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 }
 
 fn parse_dt(s: &str) -> Result<DateTime<Utc>, SqliteStorageError> {
@@ -56,7 +68,7 @@ impl Storage for SqliteStorage {
     type Error = SqliteStorageError;
 
     fn load_frames(&self) -> Result<Vec<FrameRecord>, Self::Error> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn();
 
         // Load frames ordered by start time
         let mut frame_stmt =
@@ -93,7 +105,7 @@ impl Storage for SqliteStorage {
     }
 
     fn save_frames(&self, frames: &[FrameRecord]) -> Result<(), Self::Error> {
-        let mut conn = self.conn.lock().unwrap();
+        let mut conn = self.conn();
         let tx = conn.transaction()?;
 
         tx.execute("DELETE FROM frames", [])?; // CASCADE removes frame_tags
@@ -121,7 +133,7 @@ impl Storage for SqliteStorage {
     }
 
     fn load_active(&self) -> Result<Option<ActiveFrameRecord>, Self::Error> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn();
 
         let result = conn.query_row(
             "SELECT project, start FROM active_frame WHERE lock = 1",
@@ -149,7 +161,7 @@ impl Storage for SqliteStorage {
     }
 
     fn save_active(&self, frame: Option<&ActiveFrameRecord>) -> Result<(), Self::Error> {
-        let mut conn = self.conn.lock().unwrap();
+        let mut conn = self.conn();
         let tx = conn.transaction()?;
 
         tx.execute("DELETE FROM active_frame", [])?;

--- a/rs_watson_ui/Cargo.toml
+++ b/rs_watson_ui/Cargo.toml
@@ -11,3 +11,6 @@ eframe = "0.34.2"
 rs_watson = { version = "0.3.0", path = "../rs_watson", features = ["storage-sqlite"] }
 rs_watson_storage = { version = "0.3.0", path = "../rs_watson_storage", default-features = false }
 uuid = "1.23.1"
+
+[lints]
+workspace = true


### PR DESCRIPTION
## Summary
- CLAUDE.md forbids `unwrap()`/`expect()` in production paths, but nothing enforced it
- `[workspace.lints.clippy]` denies both; every crate opts in via `[lints] workspace = true`
- `clippy.toml` exempts `#[test]` code so tests stay readable
- fixes the 5 real occurrences: 4× `conn.lock().unwrap()` in `sqlite.rs` now recover from a poisoned mutex via a private `conn()` helper (an in-flight `Transaction` rolls back on unwind, and the release profile aborts on panic anyway), and `time_utils.rs` uses `context()` instead of `expect()` in a function that already returns `Result`
- the CLI integration tests need a file-level `allow`: their setup helpers are not `#[test]` fns, so `allow-unwrap-in-tests` does not cover them

## Test plan
- [x] verified the lint bites: a temporary `unwrap()` in `rs_watson/src/report.rs` fails clippy; removed again
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test` (145 tests), `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HimprbqZLPYUKtkiAuAvUJ